### PR TITLE
Nested layouts

### DIFF
--- a/app/helpers/nestive/layout_helper.rb
+++ b/app/helpers/nestive/layout_helper.rb
@@ -89,7 +89,7 @@ module Nestive
       layout = layout.include?('/') ? layout : "layouts/#{layout}"
 
       # Capture the content to be placed inside the extended layout
-      content_for :layout, capture(&block)
+      content_for(:layout).replace capture(&block)
 
       render :file => layout
     end


### PR DESCRIPTION
Hey Justin,

Nested layouts weren't working as expected for me -- I was only getting the top-most view in the bottom-most layout. It didn't matter if I was using `:layout => nil` or not.

I took what I learned from [my nested layouts helper](http://blog.sj26.com/post/4517457786/nice-nested-layouts) and applied it to the `extends` method. Setting the `content_for :layout` means the yield inside the extended layout will correctly render the contents of the captured extends block rather than the top-most view's content.

My use case:

I have an application layout which is basically just the head and body, then a canvas layout which puts a site header, navigation and footer in place, then a page layout that adds any persistent sidebars and such for regular pages. Special controllers for dashboards and landings have `layout :canvas` while most pages inherit ApplicationController's `layout :page`. On canvas pages I can still insert weird markup like feature boxes into various places using areas. On normal pages I can append and prepend new sidebar blocks. On special-case pages I can just use the application layout and have total control. It's super-neat!

Time for some more P.R.A.I.S.E.:

Nestive is really neat! I'm using it in pretty much everything and will probably write some tests for it soon. It does what I was trying to achieve with nested layouts and solves the `content_for` problem really nicely. It's great to be able to `prepend :page, "feature box"` and such. Well done!
