### PR TITLE
Extending Partials

### DIFF
--- a/lib/nestive/layout_helper.rb
+++ b/lib/nestive/layout_helper.rb
@@ -86,7 +86,7 @@ module Nestive
       # This allows for non-linear extension trees.  More specifically, this
       # allows multiple partials to extend the same base partial and be rendered
       # in the same view
-      saved_area_for = @_area_for.clone
+      saved_area_for = !@_area_for.nil? ? @_area_for.clone : nil
 
       # Make sure it's a string
       layout = layout.to_s

--- a/lib/nestive/layout_helper.rb
+++ b/lib/nestive/layout_helper.rb
@@ -82,6 +82,12 @@ module Nestive
     #       ...
     #     <% end %>
     def extends(layout, &block)
+      # Save the current area context.
+      # This allows for non-linear extension trees.  More specifically, this
+      # allows multiple partials to extend the same base partial and be rendered
+      # in the same view
+      saved_area_for = @_area_for.clone
+
       # Make sure it's a string
       layout = layout.to_s
 
@@ -91,7 +97,12 @@ module Nestive
       # Capture the content to be placed inside the extended layout
       @view_flow.get(:layout).replace capture(&block)
 
-      render file: layout
+      results = render file: layout
+
+      # Restore the saved area context
+      @_area_for = saved_area_for
+
+      results
     end
 
     # Defines an area of content in your layout that can be modified or replaced by child layouts


### PR DESCRIPTION
I love Nestive and how it allows me to really make my html templates DRY.  I wanted to apply the same modularity to partials.  I have a few partials that are extremely similar (Content types that each need a slightly different editor) and so I wanted to leverage nestive inheritance.  

However it doesn't work.  It appears that there is only one nestive context per view render or something, because both partials end up with the same content.  

I have a setup similar to this:

``` erb
Parent partial: _parent.html.erb
<div>
  Shared Content...
  <%= yield %>
</div>

Child 1: _child1.html.erb
<%= extends "_parent" do %>
  Child 1 Content
<% end %>

Child 2: _child2.html.erb
<%= extends "_parent" do %>
  Child 2 Content
<% end %>

Main view: show.html.erb
<%= render 'child1' %>
<%= render 'child2' %>
```

The partials work, but I get the same content out of both of them as follows:

``` html
<div>
  Shared Content...
  Child 1 Content
</div>
<div>
  Shared Content...
  Child 1 Content
</div>
```

I haven't delved into the nestive code to try and figure out why yet (although I hope to find to do that today) but I thought I would ask for help here first.

Is this a use case that nestive can handle?  If not can we extend it somehow to make it work?
