### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nestive [![Build Status](https://travis-ci.org/rwz/nestive.png)](https://travis-ci.org/rwz/nestive) [![Code Climate](https://codeclimate.com/github/rwz/nestive.png)](https://codeclimate.com/github/rwz/nestive)
+# Nestive [![Build Status](https://travis-ci.org/rwz/nestive.png)](https://travis-ci.org/rwz/nestive) [![Code Climate](https://codeclimate.com/github/rwz/nestive.png)](https://codeclimate.com/github/rwz/nestive) [![Inline docs](http://inch-ci.org/github/rwz/nestive.png?branch=master)](http://inch-ci.org/github/rwz/nestive)
 ## A Nested Inheritable Layouts Helpers for Rails
 
 


### PR DESCRIPTION
Hi Pavel,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-ci.org/github/rwz/nestive.png)](http://inch-ci.org/github/rwz/nestive)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-ci.org/github/rwz/nestive/

But I guess you know that already, since Mock5 has an Inch CI badge ... Well, I would be glad if Nestive joined my little "pro documentation" movement as well :wink: 
