### PR TITLE
Consider additional parameters when extending layouts

### DIFF
--- a/lib/nestive/layout_helper.rb
+++ b/lib/nestive/layout_helper.rb
@@ -81,7 +81,7 @@ module Nestive
     #     <%= extends :admin do %>
     #       ...
     #     <% end %>
-    def extends(layout, &block)
+    def extends(layout, options={}, &block)
       # Make sure it's a string
       layout = layout.to_s
 
@@ -91,7 +91,7 @@ module Nestive
       # Capture the content to be placed inside the extended layout
       @view_flow.get(:layout).replace capture(&block)
 
-      render file: layout
+      render file: layout, locals: options
     end
 
     # Defines an area of content in your layout that can be modified or replaced by child layouts


### PR DESCRIPTION
This gem is great by the way, I have been using it for a while without any issues.

I came to a scenario where it would be great to allow the views extending a layout to pass information to the layout. This could be done with the extend method, passing an additional variable, something like this:

``` erb
<%= extends :application, wide: true do %>
  <% append :sidebar, "More content." %>
<% end %>
```

And then in `app/views/layouts/application.html.erb`, that variable can be used:

``` erb
<!DOCTYPE html>
  <html>
  <body>
    <% if wide %>
      ... do something
    <% end %>

    <%= yield %>
  </body>
</html>
```
