### PR TITLE
Ensure that purged and replaced areas are not evaluated

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ content at the start of any content previously provided by parent layouts:
 
 ``` erb
 <%= extends :application do %>
-  <%= prepend :sidebar, "Content." %>
-  <%= prepend :sidebar do %>
+  <% prepend :sidebar, "Content." %>
+  <% prepend :sidebar do %>
     Content.
   <% end %>
 <% end %>
@@ -78,8 +78,8 @@ You can also replace any content provided by parent layouts:
 
 ``` erb
 <%= extends :application do %>
-  <%= replace :sidebar, "New content." %>
-  <%= replace :sidebar do %>
+  <% replace :sidebar, "New content." %>
+  <% replace :sidebar do %>
     New content.
   <% end %>
 <% end %>

--- a/lib/nestive/layout_helper.rb
+++ b/lib/nestive/layout_helper.rb
@@ -200,8 +200,10 @@ module Nestive
     #
     # @param names
     #   A list of area names to purge
+    #
+    # @retrun [NilClass]
     def purge(*names)
-      names.each{ |name| replace(name, nil)}
+      names.each { |name| replace(name, nil) }
       nil
     end
 

--- a/lib/nestive/layout_helper.rb
+++ b/lib/nestive/layout_helper.rb
@@ -250,6 +250,7 @@ module Nestive
     #
     # @return [Boolean]
     def capture_content?(name)
+      @_area_for ||= {}
       defined_area_methods = @_area_for.fetch(name, []).map { |(method, _)| method }
       non_capture_methods = [:purge, :replace]
       (defined_area_methods & non_capture_methods).none?

--- a/lib/nestive/layout_helper.rb
+++ b/lib/nestive/layout_helper.rb
@@ -254,6 +254,5 @@ module Nestive
       non_capture_methods = [:purge, :replace]
       (defined_area_methods & non_capture_methods).none?
     end
-
   end
 end

--- a/lib/nestive/layout_helper.rb
+++ b/lib/nestive/layout_helper.rb
@@ -147,7 +147,7 @@ module Nestive
     # @param [String] content
     #   Optionally provide a String of content, instead of a block. A block will take precedence.
     def append(name, content=nil, &block)
-      content = capture(&block) if block_given?
+      content = capture(&block) if block_given? && capture_content?(name)
       add_instruction_to_area name, :push, content
     end
 
@@ -168,7 +168,7 @@ module Nestive
     # @param [String] content
     #   Optionally provide a String of content, instead of a block. A block will take precedence.
     def prepend(name, content=nil, &block)
-      content = capture(&block) if block_given?
+      content = capture(&block) if block_given? && capture_content?(name)
       add_instruction_to_area name, :unshift, content
     end
 
@@ -189,7 +189,7 @@ module Nestive
     # @param [String] content
     #   Optionally provide a String of content, instead of a block. A block will take precedence.
     def replace(name, content=nil, &block)
-      content = capture(&block) if block_given?
+      content = capture(&block) if block_given? && capture_content?(name)
       add_instruction_to_area name, :replace, [content]
     end
 

--- a/lib/nestive/layout_helper.rb
+++ b/lib/nestive/layout_helper.rb
@@ -202,6 +202,7 @@ module Nestive
     #   A list of area names to purge
     def purge(*names)
       names.each{ |name| replace(name, nil)}
+      nil
     end
 
     private

--- a/lib/nestive/layout_helper.rb
+++ b/lib/nestive/layout_helper.rb
@@ -125,7 +125,7 @@ module Nestive
     # @param [String] content
     #   An optional String of content to add to the area as you declare it.
     def area(name, content=nil, &block)
-      content = capture(&block) if block_given?
+      content = capture(&block) if block_given? && capture_content?(name)
       append name, content
       render_area name
     end
@@ -239,6 +239,19 @@ module Nestive
           output.public_send method_name, content
         end
       end.join.html_safe
+    end
+
+    # Determines if template's area is purged or replaced in the view.
+    # Used to determine if template area should be rendered
+    #
+    # @param [Symbol] name
+    #  the area to determine if content should be rendered
+    #
+    # @return [Boolean]
+    def capture_content?(name)
+      defined_area_methods = @_area_for.fetch(name, []).map { |(method, _)| method }
+      non_capture_methods = [:purge, :replace]
+      (defined_area_methods & non_capture_methods).none?
     end
 
   end

--- a/spec/controllers/nestive_spec.rb
+++ b/spec/controllers/nestive_spec.rb
@@ -59,13 +59,20 @@ describe NestiveController do
   context '#purge' do
     it 'purge single area content' do
       get :purge_single
-      assert_select 'title'
+      assert_select 'title', ''
     end
 
     it 'purge few areas content' do
       get :purge_multiple
       assert_select 'title'
       assert_select '#some-area'
+    end
+
+    context 'purge in a child whose parent replaces the area' do
+      it 'overrides the parent replace by purging the area' do
+        get :purge_override
+        assert_select 'title', ''
+      end
     end
   end
 

--- a/spec/controllers/nestive_spec.rb
+++ b/spec/controllers/nestive_spec.rb
@@ -54,6 +54,13 @@ describe NestiveController do
       get :replace
       assert_select '#some-area', 'replaced'
     end
+
+    context 'replace in a child whose parent replaces the area' do
+      it 'overrides the parent replace and does not evaluate' do
+        get :replace_override
+        assert_select 'title', 'New Title'
+      end
+    end
   end
 
   context '#purge' do

--- a/spec/internal/app/views/layouts/extend_broken.html.erb
+++ b/spec/internal/app/views/layouts/extend_broken.html.erb
@@ -1,0 +1,8 @@
+<%= extends :nestive do %>
+  <% replace :title do %>
+    <% raise 'Error, this layout is broken; children should replace this region' %>
+  <% end %>
+  <h2>extended: one</h2>
+
+  <%= yield %>
+<% end %>

--- a/spec/internal/app/views/layouts/extend_two.html.erb
+++ b/spec/internal/app/views/layouts/extend_two.html.erb
@@ -1,5 +1,5 @@
 <%= extends :extend_one do %>
-  <%= replace :some_area do %>
+  <% replace :some_area do %>
     extended: two
   <% end %>
   <%= yield %>

--- a/spec/internal/app/views/nestive/purge_override.html.erb
+++ b/spec/internal/app/views/nestive/purge_override.html.erb
@@ -1,0 +1,5 @@
+<% extends :extend_broken do %>
+  <% purge :title %>
+
+  <%= yield %>
+<% end %>

--- a/spec/internal/app/views/nestive/replace.html.erb
+++ b/spec/internal/app/views/nestive/replace.html.erb
@@ -2,6 +2,6 @@
 
 <% replace :title, 'Lolwut' %>
 
-<%= replace :some_area do %>
+<% replace :some_area do %>
   replaced
 <% end %>

--- a/spec/internal/app/views/nestive/replace_override.html.erb
+++ b/spec/internal/app/views/nestive/replace_override.html.erb
@@ -1,0 +1,6 @@
+<% extends :extend_broken do %>
+  <% replace :title do %>
+    New Title
+  <% end %>
+  <%= yield %>
+<% end %>


### PR DESCRIPTION
This fixes #20.  Purged and replaced areas from parent layouts should not be evaluated.
