### PR TITLE
Mr/fix empty extended layout

### DIFF
--- a/lib/nestive/layout_helper.rb
+++ b/lib/nestive/layout_helper.rb
@@ -89,7 +89,7 @@ module Nestive
       layout = "layouts/#{layout}" unless layout.include?('/')
 
       # Capture the content to be placed inside the extended layout
-      @view_flow.get(:layout).replace capture(&block)
+      @view_flow.get(:layout).replace capture(&block).to_s
 
       render file: layout
     end

--- a/spec/controllers/nestive_spec.rb
+++ b/spec/controllers/nestive_spec.rb
@@ -88,6 +88,10 @@ describe NestiveController do
     it 'extends empty layout' do
       get :extended_three
     end
-  end
 
+    it 'extends layout without yield' do
+      get :extended_without_yield
+      assert_select 'title', 'extended: without_yield'
+    end
+  end
 end

--- a/spec/internal/app/controllers/nestive_controller.rb
+++ b/spec/internal/app/controllers/nestive_controller.rb
@@ -10,4 +10,8 @@ class NestiveController < ApplicationController
   def extended_three
     render layout: 'extend_one'
   end
+
+  def extended_without_yield
+    render layout: 'extend_without_yield'
+  end
 end

--- a/spec/internal/app/views/layouts/extend_without_yield.html.erb
+++ b/spec/internal/app/views/layouts/extend_without_yield.html.erb
@@ -1,0 +1,3 @@
+<%= extends :nestive do %>
+  <% replace :title, 'extended: without_yield' %>
+<% end %>

--- a/spec/internal/app/views/nestive/extended_without_yield.html.erb
+++ b/spec/internal/app/views/nestive/extended_without_yield.html.erb
@@ -1,0 +1,1 @@
+<p>extended: without_yield</p>


### PR DESCRIPTION
This MR adds a test and fixes the problem described in #19. If an extended layout has no `yield` or newlines, when the block is captured, it will be `nil`, and that blows things up.